### PR TITLE
2152 cat release

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ packaged extension and they are provided under the following license:
 
 ## Release
 
-Releases are handled by the scripts in the [scripts](./scripts/) directory. These scripts were designed to run inside the [release-vscode-extension](https://github.com/openstax/ce-pipelines/blob/5a1e0a70d5931bdaa7870bb41f4bc6e2debd551f/pipelines/release-vscode-extension.yml) pipeline; however, you could also run them on your local machine with the correct credentials.
+Releases are handled by the scripts in the [scripts](./scripts/) directory.
+These scripts were designed to run inside the
+[release-vscode-extension](https://github.com/openstax/ce-pipelines/blob/5a1e0a70d5931bdaa7870bb41f4bc6e2debd551f/pipelines/release-vscode-extension.yml)
+pipeline; however, you could also run them on your local machine with the
+correct credentials.
 
-The [build script](./scripts/build-for-release.sh) tries to fetch the last version of the extension from openvsx so that it can include the previous versions of the H5P libraries in the new release. You can disable this behavior by setting the `CLEAN_H5P` environment variable before running the build. 
+The [build script](./scripts/build-for-release.sh) tries to fetch the last
+version of the extension from openvsx so that it can include the previous
+versions of the H5P libraries in the new release. You can disable this behavior
+by setting the `CLEAN_H5P` environment variable before running the build.

--- a/README.md
+++ b/README.md
@@ -152,3 +152,9 @@ packaged extension and they are provided under the following license:
 
 - What metadata should be added
 - How private solutions will be handled - Probably placeholder values
+
+## Release
+
+Releases are handled by the scripts in the [scripts](./scripts/) directory. These scripts were designed to run inside the [release-vscode-extension](https://github.com/openstax/ce-pipelines/blob/5a1e0a70d5931bdaa7870bb41f4bc6e2debd551f/pipelines/release-vscode-extension.yml) pipeline; however, you could also run them on your local machine with the correct credentials.
+
+The [build script](./scripts/build-for-release.sh) tries to fetch the last version of the extension from openvsx so that it can include the previous versions of the H5P libraries in the new release. You can disable this behavior by setting the `CLEAN_H5P` environment variable before running the build. 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4085,9 +4085,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -8510,9 +8510,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -11992,9 +11992,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -15228,9 +15228,9 @@
       }
     },
     "vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vscode-h5p",
+  "name": "cat",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-h5p",
+      "name": "cat",
       "version": "0.0.1",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "vscode-h5p",
-  "displayName": "H5P Viewer",
+  "name": "cat",
+  "displayName": "Content Assessment Tool",
   "publisher": "openstax",
   "description": "Visualize H5P files in VS Code",
   "version": "0.0.1",
-  "author": "OpenStax",
+  "author": "openstax",
   "license": "MIT",
   "homepage": "https://openstax.org/",
   "repository": {

--- a/scripts/build-for-release.sh
+++ b/scripts/build-for-release.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+
+set -eu
+test "${TRACE_ON:-0}" -eq 1 && set -x
+
+REPO_ROOT="${REPO_ROOT:?}"
+SERVER_OUT="${SERVER_OUT:?}"
+VERSION="${VERSION:?}"
+NAME="${NAME:?}"
+PUBLISHER="${PUBLISHER:?}"
+
+fetch_include_past_h5p() {
+	(
+		trap 'rm -rf $tmp_path' EXIT
+		tmp_path="$(mktemp -d)"
+		download_path="$tmp_path/extension.vsix"
+		# Download the latest version of the extension
+		curl -sSL \
+			"https://open-vsx.org/api/$PUBLISHER/$NAME/latest/file/download" \
+			-o "$download_path"
+		cd "$tmp_path"
+		unzip -q "$download_path"
+		files="$(find "$tmp_path" -name "*.tar.gz")"
+		# There should only be one matching archive at the moment
+		count="$(echo "$files" | awk '$0' | wc -l)"
+		count_expected=1
+		[ "$count" -eq "$count_expected" ] || {
+			echo "ERROR: Expected $count_expected file(s), found $count"
+			exit 1
+		}
+		# Move the files into the output for postbuild script to use
+		echo "$files" | while read -r f; do mv "$f" "$SERVER_OUT"; done
+	)
+}
+
+cd "$REPO_ROOT"
+jq --arg version "$VERSION"  '. + {version: $version}' \
+    package.json > package-with-version.json
+mv package-with-version.json package.json
+npm install
+npm run clean
+fetch_include_past_h5p
+npm run package

--- a/scripts/build-for-release.sh
+++ b/scripts/build-for-release.sh
@@ -39,5 +39,5 @@ jq --arg version "$VERSION"  '. + {version: $version}' \
 mv package-with-version.json package.json
 npm install
 npm run clean
-fetch_include_past_h5p
+[ -z "${CLEAN_H5P:-}" ] && fetch_include_past_h5p
 npm run package

--- a/scripts/publish-openvsx.sh
+++ b/scripts/publish-openvsx.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+set -eu
+set +x # do not echo secrets
+
+OPENVSX_TOKEN="${OPENVSX_TOKEN:?}"
+VERSION="${VERSION:?}"
+NAME="${NAME:?}"
+PUBLISHER="${PUBLISHER:?}"
+
+here="$(cd "$(dirname "$0")"; pwd)"
+repo_root="$(realpath "$here/..")"
+server_out="$repo_root/server/out"
+
+
+REPO_ROOT="$repo_root" \
+SERVER_OUT="$server_out" \
+VERSION="$VERSION" \
+NAME="$NAME" \
+PUBLISHER="$PUBLISHER" \
+"$here"/build-for-release.sh
+
+cd "$repo_root"
+extension="$(echo "./$NAME-"*.vsix)"
+echo "Publishing $extension" | grep -vF '*' || {
+	ls
+	echo "No matching vsix file was found. (./$NAME-*.vsix)"
+	exit 1
+}
+npm install ovsx
+npx ovsx publish "$extension" -p "$OPENVSX_TOKEN"

--- a/scripts/publish-vsce.sh
+++ b/scripts/publish-vsce.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+set -eu
+set +x # do not echo secrets
+
+VSCE_TOKEN="${VSCE_TOKEN:?}"
+VERSION="${VERSION:?}"
+NAME="${NAME:?}"
+PUBLISHER="${PUBLISHER:?}"
+
+here="$(cd "$(dirname "$0")"; pwd)"
+repo_root="$(realpath "$here/..")"
+server_out="$repo_root/server/out"
+
+
+REPO_ROOT="$repo_root" \
+SERVER_OUT="$server_out" \
+VERSION="${VERSION:?}" \
+NAME="${NAME:?}" \
+PUBLISHER="${PUBLISHER:?}" \
+"$here"/build-for-release.sh
+
+cd "$repo_root"
+extension="$(echo "./$NAME-"*.vsix)"
+echo "Publishing $extension" | grep -vF '*' || {
+	ls
+	echo "No matching vsix file was found. (./$NAME-*.vsix)"
+	exit 1
+}
+echo "${VSCE_TOKEN}" | npx vsce login "$PUBLISHER"
+npx vsce publish "$VERSION"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3639,9 +3639,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -10140,9 +10140,9 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "form-data": {
       "version": "4.0.0",

--- a/server/scripts/postbuild.ts
+++ b/server/scripts/postbuild.ts
@@ -60,10 +60,7 @@ const SERVER_ROOT = path.resolve(__dirname, '..');
 const NODE_MODULES = path.resolve(SERVER_ROOT, 'node_modules');
 const DST_OUT = path.resolve(SERVER_ROOT, 'out');
 const SRC_H5P_ROOT = path.resolve(SERVER_ROOT, 'h5p-php');
-const ARCHIVE_FILE =
-  process.argv[2] === undefined
-    ? path.resolve(DST_OUT, Config.h5pServerArchiveName)
-    : path.resolve(process.argv[2]);
+const ARCHIVE_FILE = path.resolve(DST_OUT, Config.h5pServerArchiveName);
 
 const MISC_COPIES = [
   {


### PR DESCRIPTION
Add scripts to build and publish the extension. These scripts were designed to run inside the [release-vscode-extension](https://github.com/openstax/ce-pipelines/blob/5a1e0a70d5931bdaa7870bb41f4bc6e2debd551f/pipelines/release-vscode-extension.yml) pipeline; however, you could also run them on your local machine with the correct credentials.

One caveat is that the build script tries to fetch the last version of the extension from openvsx so that it can include the previous versions of the H5P libraries. Since the extension has not been published to openvsx yet, this part will fail.