### PR TITLE
Remove attachments after all have been copied

### DIFF
--- a/server/src/models/OpenStax/FileContentStorage.spec.ts
+++ b/server/src/models/OpenStax/FileContentStorage.spec.ts
@@ -530,7 +530,22 @@ describe('File Content Storage', () => {
     expect(paths.public).toBeDefined();
     expect(paths.private).toBeDefined();
 
-    // WHEN: Image is not longer referenced in either location
+    // WHEN: Image is no longer referenced in public content
+    await storage.addContent(
+      {} as unknown as IContentMetadata,
+      {
+        ...baseContent,
+        text: '',
+      },
+      {} as unknown as IUser,
+      id,
+    );
+    // THEN: Image is not in public storage
+    paths = await findFilePaths(id, image);
+    expect(paths.public).not.toBeDefined();
+    expect(paths.private).toBeDefined();
+
+    // WHEN: Image is no longer referenced in either location
     await storage.addContent(
       {} as unknown as IContentMetadata,
       {

--- a/server/src/models/OpenStax/FileContentStorage.spec.ts
+++ b/server/src/models/OpenStax/FileContentStorage.spec.ts
@@ -85,7 +85,7 @@ describe('File Content Storage', () => {
   beforeEach(() => {
     mockfs({
       [VIRTUAL_ROOT]: {
-        ['interactives']: {
+        interactives: {
           '1': {
             'h5p.json': JSON.stringify({
               ...MOCK_H5P_BASE,
@@ -451,6 +451,100 @@ describe('File Content Storage', () => {
     expect(await findFilePath(id, image)).toMatch(
       new RegExp(`${VIRTUAL_ROOT}/${CONFIG.contentPath}`),
     );
+  });
+  it('correctly handles unreferenced images', async () => {
+    mockfs({
+      [VIRTUAL_ROOT]: {
+        interactives: {
+          '1': {
+            media: {
+              'a.png': '<contents of a.png>',
+            },
+          },
+        },
+        private: {
+          interactives: {
+            '1': {
+              ['content.json']: JSON.stringify({
+                text: '<img src="media/a.png"/>',
+              }),
+              media: {
+                'a.png': '<contents of a.png>',
+              },
+            },
+          },
+        },
+      },
+    });
+    const storage = createStorageHarness();
+    const findFilePaths = tryGet(storage, '_findFilePaths').bind(storage);
+    const image = 'media/a.png';
+    const id = '1';
+    const baseContent = {
+      text: `<img src="${image}"/>`,
+      questions: [`<img src="${image}"/>`],
+      osMeta: {
+        nickname: id,
+        is_solution_public: false,
+      },
+    };
+    let paths: Partial<Record<'public' | 'private', string>>;
+    await storage.addContent(
+      {} as unknown as IContentMetadata,
+      baseContent,
+      {} as unknown as IUser,
+      id,
+    );
+    // Image should exist in both public and private storage
+    paths = await findFilePaths(id, image);
+    expect(paths.public).toBeDefined();
+    expect(paths.private).toBeDefined();
+
+    // WHEN: Solutions are made public
+    await storage.addContent(
+      {} as unknown as IContentMetadata,
+      {
+        ...baseContent,
+        osMeta: {
+          ...baseContent.osMeta,
+          is_solution_public: true,
+        },
+      },
+      {} as unknown as IUser,
+      id,
+    );
+    // THEN: Only the public storage should contain the image
+    paths = await findFilePaths(id, image);
+    expect(paths.public).toBeDefined();
+    expect(paths.private).not.toBeDefined();
+
+    // WHEN: Solutions are made private again
+    await storage.addContent(
+      {} as unknown as IContentMetadata,
+      baseContent,
+      {} as unknown as IUser,
+      id,
+    );
+    // THEN: Both public and private storage should contain the image
+    paths = await findFilePaths(id, image);
+    expect(paths.public).toBeDefined();
+    expect(paths.private).toBeDefined();
+
+    // WHEN: Image is not longer referenced in either location
+    await storage.addContent(
+      {} as unknown as IContentMetadata,
+      {
+        ...baseContent,
+        questions: [''],
+        text: '',
+      },
+      {} as unknown as IUser,
+      id,
+    );
+    // THEN: Image is gone
+    paths = await findFilePaths(id, image);
+    expect(paths.public).not.toBeDefined();
+    expect(paths.private).not.toBeDefined();
   });
   it('still works when the contentPath does not exist', async () => {
     mockfs({

--- a/server/src/models/OpenStax/FileContentStorage.ts
+++ b/server/src/models/OpenStax/FileContentStorage.ts
@@ -187,7 +187,7 @@ export default class OSStorage extends H5P.fsImplementations
     await Promise.all(
       attachments.map(async (item) => {
         const paths = await this._findFilePaths(id, item);
-        // if its location does not match its visibility copy it
+        // if its location does not match its visibility, copy it
         const [missing, loc] = isPrivate
           ? [paths.private === undefined, paths.public]
           : [paths.public === undefined, paths.private];
@@ -242,9 +242,9 @@ export default class OSStorage extends H5P.fsImplementations
           true,
         )),
       );
+      // write private data to private content.json file
       await this.writeJSON(realId, CONTENT_NAME, privateData, true);
 
-      // write sanitized content object to content.json file
       publicAttachments.push(
         ...(await this._handleAttachmentsInContent(
           realId,
@@ -253,6 +253,7 @@ export default class OSStorage extends H5P.fsImplementations
           false,
         )),
       );
+      // write sanitized content object to content.json file
       await this.writeJSON(realId, CONTENT_NAME, sanitized, false);
     } else {
       publicAttachments.push(

--- a/server/src/models/OpenStax/FileContentStorage.ts
+++ b/server/src/models/OpenStax/FileContentStorage.ts
@@ -185,25 +185,20 @@ export default class OSStorage extends H5P.fsImplementations
     validateContent(content);
     await this.moveTempFiles(replaced, id, user, isPrivate);
     await Promise.all(
-      Array.from(attachments).map(async (attachment) => {
-        const location = assertValue(
-          await this._findFilePath(id, attachment),
-          `Could not find image: ${attachment}`,
-        );
-        const locationIsPrivate = location.includes(
-          this.privateContentDirectory,
-        );
-        // if its location does not match its visibility
-        if (isPrivate !== locationIsPrivate) {
-          // copy it
+      attachments.map(async (item) => {
+        const paths = await this._findFilePaths(id, item);
+        // if its location does not match its visibility copy it
+        const [missing, loc] = isPrivate
+          ? [paths.private === undefined, paths.public]
+          : [paths.public === undefined, paths.private];
+        if (missing) {
+          const src = assertValue(loc, `Could not find attachment: ${item}`);
           await this._addFile(
             id,
-            attachment,
-            fsExtra.createReadStream(location),
+            item,
+            fsExtra.createReadStream(src),
             isPrivate,
           );
-          // remove the old one
-          await fsExtra.rm(location);
         }
       }),
     );
@@ -231,33 +226,36 @@ export default class OSStorage extends H5P.fsImplementations
     assertTrue(realId !== '0', 'Content id cannot be 0');
     const newOsMeta = mergeMetadata(await this.getOSMeta(realId), osMeta);
     const oldAttachments = newOsMeta.attachments ?? [];
-    const newAttachments: string[] = [];
+    const privateAttachments: string[] = [];
+    const publicAttachments: string[] = [];
     if (!isSolutionPublic(osMeta)) {
       const [sanitized, privateData] = yankAnswers(
         content,
         metadata.mainLibrary,
       );
       // Replace images in private content
-      const privateAttachments = await this._handleAttachmentsInContent(
-        realId,
-        privateData,
-        user,
-        true,
+      privateAttachments.push(
+        ...(await this._handleAttachmentsInContent(
+          realId,
+          privateData,
+          user,
+          true,
+        )),
       );
       await this.writeJSON(realId, CONTENT_NAME, privateData, true);
 
       // write sanitized content object to content.json file
-      const publicAttachments = await this._handleAttachmentsInContent(
-        realId,
-        sanitized,
-        user,
-        false,
+      publicAttachments.push(
+        ...(await this._handleAttachmentsInContent(
+          realId,
+          sanitized,
+          user,
+          false,
+        )),
       );
       await this.writeJSON(realId, CONTENT_NAME, sanitized, false);
-      newAttachments.push(...publicAttachments);
-      newAttachments.push(...privateAttachments);
     } else {
-      newAttachments.push(
+      publicAttachments.push(
         ...(await this._handleAttachmentsInContent(
           realId,
           content,
@@ -270,26 +268,27 @@ export default class OSStorage extends H5P.fsImplementations
     }
 
     // Add attachments from metadata
-    const metaAttachments = await this._handleAttachmentsInContent(
-      realId,
-      newOsMeta,
-      user,
-      false,
+    publicAttachments.push(
+      ...(await this._handleAttachmentsInContent(
+        realId,
+        newOsMeta,
+        user,
+        false,
+      )),
     );
 
-    newAttachments.push(...metaAttachments);
-    const attachmentSet = new Set(newAttachments);
+    for (const name of oldAttachments) {
+      const paths = await this._findFilePaths(realId, name);
+      if (paths.private !== undefined && !privateAttachments.includes(name)) {
+        fsExtra.rmSync(paths.private);
+      }
+      if (paths.public !== undefined && !publicAttachments.includes(name)) {
+        fsExtra.rmSync(paths.public);
+      }
+    }
 
-    newOsMeta.attachments = Array.from(attachmentSet);
-    await Promise.all(
-      oldAttachments.map(async (attachment) => {
-        if (!attachmentSet.has(attachment)) {
-          const fullPath = await this._findFilePath(realId, attachment);
-          if (fullPath !== undefined) {
-            await fsExtra.rm(fullPath);
-          }
-        }
-      }),
+    newOsMeta.attachments = Array.from(
+      new Set(publicAttachments.concat(privateAttachments)),
     );
 
     await Promise.all([
@@ -356,16 +355,19 @@ export default class OSStorage extends H5P.fsImplementations
     }
   }
 
+  private async _findFilePaths(id: string, filename: string) {
+    const pathTuples: [string, string][] = [
+      ['public', path.join(this.contentPath, id, filename)],
+      ['private', path.join(this.privateContentDirectory, id, filename)],
+    ];
+    const paths: Partial<Record<'public' | 'private', string>> =
+      Object.fromEntries(pathTuples.filter((t) => fsExtra.existsSync(t[1])));
+    return paths;
+  }
+
   private async _findFilePath(id: string, filename: string) {
-    const publicPath = path.join(this.contentPath, id, filename);
-    const privatePath = path.join(this.privateContentDirectory, id, filename);
-    if (await fsExtra.exists(publicPath)) {
-      return publicPath;
-    } else if (await fsExtra.exists(privatePath)) {
-      return privatePath;
-    } else {
-      return undefined;
-    }
+    const paths = await this._findFilePaths(id, filename);
+    return paths.public ?? paths.private;
   }
 
   public override async getFileStats(


### PR DESCRIPTION
Removing them as they were being copied was error prone

---

For CAT working version >= 0.0.19

---

# Images saved in both public and private when they are referenced in question and private solution
## GIVEN
- A newly created H5P that contains the same image in the question and answer portion
## WHEN
- The newly created H5P is saved
## THEN
- The image is saved in both the `interactives/<content-id>/media` and `private/interactives/<content-id>/media` directories

---

# Save does the same thing on subsequent saves
## GIVEN
- An existing H5P that contains the same image in the question and answer portion
## WHEN
- The editor is closed and opened again
- The H5P is saved
## THEN
- Nothing happens (same outcome as before, image in public and private)

---

# Making the solution public causes the private version of the image to be removed
## GIVEN
- An existing H5P that contains the same image in the question and answer portion
## WHEN
- The solution is made public
- The H5P is saved
## THEN
- The image is removed from `private/interactives/<content-id>/media`, but remains in `interactives/<content-id>/media`

---

# Making solution private again causes the private version of the image to be recreated
## GIVEN
- An existing H5P that contains the same image in the question and answer portion
- The H5P solution is public
## WHEN
- The solution is made private
- The H5P is saved
## THEN
- The image is saved in both the `interactives/<content-id>/media` and `private/interactives/<content-id>/media` directories

---

# Image is deleted from `interactives/<content-id>/media` when not referenced in question
## GIVEN
- An existing H5P that contains the same image in the question and answer portion
## WHEN
- The image is removed from the question
- The H5P is saved
## THEN
- The image is removed from `interactives/<content-id>/media`, but remains in `private/interactives/<content-id>/media`

---

# Removing all image references causes all images to be deleted
## GIVEN
- An existing H5P that contains the same image in the question and answer portion
## WHEN
- The image is removed from the question and answer
- The H5P is saved
## THEN
- The image is removed from `interactives/<content-id>/media` and `private/interactives/<content-id>/media`



