### PR TITLE
2174 private collaborator solutions

### DIFF
--- a/server/src/models/OpenStax/AnswerYankers.spec.ts
+++ b/server/src/models/OpenStax/AnswerYankers.spec.ts
@@ -1,5 +1,5 @@
 import { recursiveMerge } from '../../utils';
-import { yankByKeysFactory } from './AnswerYankers';
+import { chain, yankByKeysFactory } from './AnswerYankers';
 
 describe('AnswerYankers', () => {
   describe('yankByKeysFactory', () => {
@@ -30,6 +30,24 @@ describe('AnswerYankers', () => {
       expect(recursiveMerge(publicData, privateData)).toStrictEqual(
         fakeContent,
       );
+    });
+  });
+  describe('chain', () => {
+    it('chains correctly', () => {
+      const fakeContent = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+      };
+      const [pub, priv] = chain(
+        yankByKeysFactory('a'),
+        yankByKeysFactory('b'),
+        yankByKeysFactory('b'),
+        yankByKeysFactory('c'),
+      )(fakeContent);
+      expect(pub).toStrictEqual({ d: 4 });
+      expect(priv).toStrictEqual({ a: 1, b: 2, c: 3 });
     });
   });
 });

--- a/server/src/models/OpenStax/AnswerYankers.spec.ts
+++ b/server/src/models/OpenStax/AnswerYankers.spec.ts
@@ -1,12 +1,12 @@
+import { recursiveMerge } from '../../utils';
 import {
   Yanker,
   blanksYanker,
   multiChoiceYanker,
-  questionSetMerge,
-  questionSetYanker,
   shallowMerge,
   trueFalseYanker,
 } from './AnswerYankers';
+import Config from './config';
 
 describe('AnswerYankers', () => {
   const yankByKeyTests: Array<[string, Yanker, string]> = [
@@ -90,12 +90,15 @@ describe('AnswerYankers', () => {
         ],
       };
       const copy = { ...fakeContent };
-      const [publicData, privateData] = questionSetYanker(fakeContent);
+      const questionSetYanker =
+        Config.supportedLibraries['H5P.QuestionSet']?.yankAnswers;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const [publicData, privateData] = questionSetYanker!(fakeContent);
       // No modifications to original
       expect(copy).toStrictEqual(fakeContent);
       expect(publicData).toMatchSnapshot();
       expect(privateData).toMatchSnapshot();
-      expect(questionSetMerge(publicData, privateData)).toStrictEqual(
+      expect(recursiveMerge(publicData, privateData)).toStrictEqual(
         fakeContent,
       );
     });

--- a/server/src/models/OpenStax/AnswerYankers.spec.ts
+++ b/server/src/models/OpenStax/AnswerYankers.spec.ts
@@ -1,22 +1,17 @@
 import { recursiveMerge } from '../../utils';
-import {
-  Yanker,
-  blanksYanker,
-  multiChoiceYanker,
-  shallowMerge,
-  trueFalseYanker,
-} from './AnswerYankers';
+import { yankByKeysFactory } from './AnswerYankers';
 import Config from './config';
 
 describe('AnswerYankers', () => {
-  const yankByKeyTests: Array<[string, Yanker, string]> = [
-    ['blanksYanker', blanksYanker, 'questions'],
-    ['multiChoiceYanker', multiChoiceYanker, 'answers'],
-    ['trueFalseYanker', trueFalseYanker, 'correct'],
+  const yankByKeyTests: Array<[string, string]> = [
+    ['blanksYanker', 'questions'],
+    ['multiChoiceYanker', 'answers'],
+    ['trueFalseYanker', 'correct'],
   ];
-  yankByKeyTests.forEach(([name, func, key]) => {
+  yankByKeyTests.forEach(([name, key]) => {
     describe(name, () => {
       it(`yanks ${key} without side effects`, () => {
+        const func = yankByKeysFactory(key);
         // The actual information does not matter
         // We are testing that it pulls out the correct key without side effects
         const fakeContent = {
@@ -35,7 +30,7 @@ describe('AnswerYankers', () => {
         expect('otherInformation' in (privateData as any)).toBe(false);
 
         // Merge them back together
-        expect(shallowMerge(publicData, privateData)).toStrictEqual(
+        expect(recursiveMerge(publicData, privateData)).toStrictEqual(
           fakeContent,
         );
       });

--- a/server/src/models/OpenStax/AnswerYankers.ts
+++ b/server/src/models/OpenStax/AnswerYankers.ts
@@ -1,5 +1,3 @@
-import { assertValue } from '../../../../common/src/utils';
-
 export type Yanker = (content: any) => [unknown, unknown];
 export type Unyanker = (publicData: any, privateData: any) => unknown;
 
@@ -22,38 +20,6 @@ export const blanksYanker: Yanker = (content) => {
 
 export const multiChoiceYanker: Yanker = (content) => {
   return yankByKeys(content, ['answers']);
-};
-
-export const questionSetYanker: Yanker = (content) => {
-  const yankBySubtype = (q: any) => {
-    const library = assertValue<string>(q.library);
-    const [libraryName] = library.split(' ');
-    switch (libraryName) {
-      case 'H5P.MultiChoice':
-        return multiChoiceYanker(q.params);
-      case 'H5P.Blanks':
-        return blanksYanker(q.params);
-      case 'H5P.TrueFalse':
-        return trueFalseYanker(q.params);
-      /* istanbul ignore next */
-      default:
-        throw new Error(`Library, "${libraryName}," is unsupported`);
-    }
-  };
-  const privateData: unknown[] = [];
-  const publicData = {
-    ...content,
-    // NOTE: Impure map
-    questions: content.questions.map((q: any) => {
-      const [pub, priv] = yankBySubtype(q);
-      privateData.push(priv);
-      return {
-        ...q,
-        params: pub,
-      };
-    }),
-  };
-  return [publicData, privateData];
 };
 
 export const questionSetMerge: Unyanker = (

--- a/server/src/models/OpenStax/AnswerYankers.ts
+++ b/server/src/models/OpenStax/AnswerYankers.ts
@@ -1,4 +1,8 @@
-export type Yanker = (content: Partial<unknown>) => [unknown, unknown];
+import { recursiveMerge } from '../../utils';
+
+export type Yanker = (
+  content: Partial<unknown>,
+) => [Partial<unknown>, Partial<unknown>];
 
 export function yankByKeys(
   content: Partial<unknown>,
@@ -20,3 +24,11 @@ export const yankByKeysFactory = (...keys: string[]) => {
   return (content: Partial<unknown>): [Partial<unknown>, Partial<unknown>] =>
     yankByKeys(content, keys);
 };
+
+export const chain =
+  (a: Yanker, b: Yanker): Yanker =>
+  (content) => {
+    const [pub1, priv1] = a(content);
+    const [pub2, priv2] = b(pub1);
+    return [pub2, recursiveMerge(priv1, priv2) as Partial<unknown>];
+  };

--- a/server/src/models/OpenStax/AnswerYankers.ts
+++ b/server/src/models/OpenStax/AnswerYankers.ts
@@ -26,9 +26,14 @@ export const yankByKeysFactory = (...keys: string[]) => {
 };
 
 export const chain =
-  (a: Yanker, b: Yanker): Yanker =>
+  (...yankers: Yanker[]): Yanker =>
   (content) => {
-    const [pub1, priv1] = a(content);
-    const [pub2, priv2] = b(pub1);
-    return [pub2, recursiveMerge(priv1, priv2) as Partial<unknown>];
+    let pub: Partial<unknown> = content;
+    let priv: Partial<unknown> = {};
+    for (const yanker of yankers) {
+      const [publicData, privateData] = yanker(pub);
+      pub = publicData;
+      priv = recursiveMerge(priv, privateData) as Partial<unknown>;
+    }
+    return [pub, priv];
   };

--- a/server/src/models/OpenStax/AnswerYankers.ts
+++ b/server/src/models/OpenStax/AnswerYankers.ts
@@ -1,9 +1,11 @@
-export type Yanker = (content: any) => [unknown, unknown];
-export type Unyanker = (publicData: any, privateData: any) => unknown;
+export type Yanker = (content: Partial<unknown>) => [unknown, unknown];
 
-function yankByKeys(content: any, keys: string[]): [unknown, unknown] {
-  const publicData: Record<string, any> = {};
-  const privateData: Record<string, any> = {};
+export function yankByKeys(
+  content: Partial<unknown>,
+  keys: string[],
+): [Partial<unknown>, Partial<unknown>] {
+  const publicData: Record<string, unknown> = {};
+  const privateData: Record<string, unknown> = {};
   Object.entries(content).forEach(([k, v]) => {
     if (keys.includes(k)) {
       privateData[k] = v;
@@ -14,30 +16,7 @@ function yankByKeys(content: any, keys: string[]): [unknown, unknown] {
   return [publicData, privateData];
 }
 
-export const blanksYanker: Yanker = (content) => {
-  return yankByKeys(content, ['questions']);
+export const yankByKeysFactory = (...keys: string[]) => {
+  return (content: Partial<unknown>): [Partial<unknown>, Partial<unknown>] =>
+    yankByKeys(content, keys);
 };
-
-export const multiChoiceYanker: Yanker = (content) => {
-  return yankByKeys(content, ['answers']);
-};
-
-export const questionSetMerge: Unyanker = (
-  publicData: any,
-  privateData: any,
-) => {
-  const copy = { ...publicData };
-  copy.questions.forEach((q: any, idx: number) => {
-    q.params = shallowMerge(q.params, privateData[idx]);
-  });
-  return copy;
-};
-
-export const trueFalseYanker: Yanker = (content) => {
-  return yankByKeys(content, ['correct']);
-};
-
-export const shallowMerge: Unyanker = (publicData: any, privateData: any) => ({
-  ...publicData,
-  ...privateData,
-});

--- a/server/src/models/OpenStax/FileContentStorage.ts
+++ b/server/src/models/OpenStax/FileContentStorage.ts
@@ -222,8 +222,6 @@ export default class OSStorage extends H5P.fsImplementations
     const privateAttachments: string[] = [];
     const publicAttachments: string[] = [];
     if (!isSolutionPublic(osMeta)) {
-      // TODO: Take collaborator solutions out of content and put them
-      // in private metadata.json or content.json
       const [sanitized, privateData] = yankAnswers(
         content,
         metadata.mainLibrary,

--- a/server/src/models/OpenStax/FileContentStorage.ts
+++ b/server/src/models/OpenStax/FileContentStorage.ts
@@ -26,7 +26,7 @@ function assertLibrary(mainLibrary: string) {
 }
 
 function yankAnswers(
-  content: unknown,
+  content: Partial<unknown>,
   mainLibrary: string,
 ): [unknown, unknown] {
   return assertLibrary(mainLibrary).yankAnswers(content);

--- a/server/src/models/OpenStax/__snapshots__/AnswerYankers.spec.ts.snap
+++ b/server/src/models/OpenStax/__snapshots__/AnswerYankers.spec.ts.snap
@@ -30,39 +30,47 @@ exports[`AnswerYankers questionSetYanker yanks private data by subtype 1`] = `
 `;
 
 exports[`AnswerYankers questionSetYanker yanks private data by subtype 2`] = `
-[
-  {
-    "correct": false,
-  },
-  {
-    "answers": [
-      {
+{
+  "questions": [
+    {
+      "params": {
         "correct": false,
-        "text": "<div>3</div>
-",
-        "tipsAndFeedback": {
-          "chosenFeedback": "",
-          "notChosenFeedback": "",
-          "tip": "",
-        },
       },
-      {
-        "correct": true,
-        "text": "<div>4</div>
+    },
+    {
+      "params": {
+        "answers": [
+          {
+            "correct": false,
+            "text": "<div>3</div>
 ",
-        "tipsAndFeedback": {
-          "chosenFeedback": "",
-          "notChosenFeedback": "",
-          "tip": "",
-        },
+            "tipsAndFeedback": {
+              "chosenFeedback": "",
+              "notChosenFeedback": "",
+              "tip": "",
+            },
+          },
+          {
+            "correct": true,
+            "text": "<div>4</div>
+",
+            "tipsAndFeedback": {
+              "chosenFeedback": "",
+              "notChosenFeedback": "",
+              "tip": "",
+            },
+          },
+        ],
       },
-    ],
-  },
-  {
-    "questions": [
-      "<p>What is *true*?</p>
+    },
+    {
+      "params": {
+        "questions": [
+          "<p>What is *true*?</p>
 ",
-    ],
-  },
-]
+        ],
+      },
+    },
+  ],
+}
 `;

--- a/server/src/models/OpenStax/__snapshots__/config.spec.ts.snap
+++ b/server/src/models/OpenStax/__snapshots__/config.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AnswerYankers questionSetYanker yanks private data by subtype 1`] = `
+exports[`questionSetYanker yanks private data by subtype 1`] = `
 {
   "questions": [
     {
@@ -29,7 +29,7 @@ exports[`AnswerYankers questionSetYanker yanks private data by subtype 1`] = `
 }
 `;
 
-exports[`AnswerYankers questionSetYanker yanks private data by subtype 2`] = `
+exports[`questionSetYanker yanks private data by subtype 2`] = `
 {
   "questions": [
     {

--- a/server/src/models/OpenStax/config.spec.ts
+++ b/server/src/models/OpenStax/config.spec.ts
@@ -1,0 +1,63 @@
+import { recursiveMerge } from '../../utils';
+import Config from './config';
+
+describe('questionSetYanker', () => {
+  it('yanks private data by subtype', () => {
+    const fakeContent = {
+      questions: [
+        {
+          params: {
+            question: '<p>Given point a and point b, what is 1+1?</p>\n',
+            correct: false,
+          },
+          library: 'H5P.TrueFalse 1.16',
+        },
+        {
+          params: {
+            question: '<p>Given point a and point b, what is 2+2?</p>\n',
+            answers: [
+              {
+                correct: false,
+                tipsAndFeedback: {
+                  tip: '',
+                  chosenFeedback: '',
+                  notChosenFeedback: '',
+                },
+                text: '<div>3</div>\n',
+              },
+              {
+                correct: true,
+                tipsAndFeedback: {
+                  tip: '',
+                  chosenFeedback: '',
+                  notChosenFeedback: '',
+                },
+                text: '<div>4</div>\n',
+              },
+            ],
+          },
+          library: 'H5P.MultiChoice 1.16',
+        },
+        {
+          params: {
+            media: {
+              disableImageZooming: false,
+            },
+            questions: ['<p>What is *true*?</p>\n'],
+          },
+          library: 'H5P.Blanks 1.14',
+        },
+      ],
+    };
+    const copy = JSON.parse(JSON.stringify(fakeContent));
+    const questionSetYanker =
+      Config.supportedLibraries['H5P.QuestionSet']?.yankAnswers;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [publicData, privateData] = questionSetYanker!(fakeContent);
+    // No modifications to original
+    expect(copy).toStrictEqual(fakeContent);
+    expect(publicData).toMatchSnapshot();
+    expect(privateData).toMatchSnapshot();
+    expect(recursiveMerge(publicData, privateData)).toStrictEqual(fakeContent);
+  });
+});

--- a/server/src/models/OpenStax/config.ts
+++ b/server/src/models/OpenStax/config.ts
@@ -66,7 +66,9 @@ const metadataFields: AdditionalField[] = [
   { field: detailedSolution, private: true },
 ];
 
-function newSupportedLibrary(options?: LibraryOptions): SupportedLibrary {
+export function newSupportedLibrary(
+  options?: LibraryOptions,
+): SupportedLibrary {
   const privateKeys = options?.privateKeys ?? [];
   const additionalFields = options?.semantics?.additionalFields;
   if (additionalFields !== undefined) {
@@ -76,15 +78,19 @@ function newSupportedLibrary(options?: LibraryOptions): SupportedLibrary {
         .map((f) => f.field.name),
     );
   }
-  const keyYanker = yankByKeysFactory(...privateKeys);
+  const keyYanker =
+    privateKeys.length > 0 ? yankByKeysFactory(...privateKeys) : undefined;
   const yankAnswers: Yanker | undefined =
-    options?.yankAnswers !== undefined
+    options?.yankAnswers !== undefined && keyYanker !== undefined
       ? chain(options.yankAnswers, keyYanker)
-      : keyYanker;
+      : keyYanker ?? options?.yankAnswers;
 
   return {
     semantics: options?.semantics,
-    yankAnswers: yankAnswers,
+    yankAnswers: assertValue(
+      yankAnswers,
+      'BUG: Expected answer yanker, got undefined',
+    ),
   };
 }
 

--- a/server/src/models/OpenStax/config.ts
+++ b/server/src/models/OpenStax/config.ts
@@ -1,19 +1,10 @@
 import * as H5P from '@lumieducation/h5p-server';
-import {
-  Unyanker,
-  Yanker,
-  blanksYanker,
-  multiChoiceYanker,
-  questionSetMerge,
-  shallowMerge,
-  trueFalseYanker,
-} from './AnswerYankers';
+import { Yanker, yankByKeysFactory } from './AnswerYankers';
 import { ISemanticsEntry } from '@lumieducation/h5p-server/build/src/types';
 import { assertValue } from '../../../../common/src/utils';
 
 interface SupportedLibrary {
   yankAnswers: Yanker;
-  unyankAnswers: Unyanker;
   // Semantic overrides are utilized in the H5PEditor's alterLibrarySemantics
   semantics?: {
     /**
@@ -84,8 +75,10 @@ export default class Config {
   public static readonly supportedLibraries: Record<string, SupportedLibrary> =
     {
       'H5P.Blanks': {
-        yankAnswers: blanksYanker,
-        unyankAnswers: shallowMerge,
+        yankAnswers: yankByKeysFactory(
+          'questions',
+          ...metadataFields.map((f) => f.field.name),
+        ),
         semantics: {
           additionalFields: metadataFields,
           override(entry) {
@@ -103,8 +96,10 @@ export default class Config {
         },
       },
       'H5P.MultiChoice': {
-        yankAnswers: multiChoiceYanker,
-        unyankAnswers: shallowMerge,
+        yankAnswers: yankByKeysFactory(
+          'answers',
+          ...metadataFields.map((f) => f.field.name),
+        ),
         semantics: {
           additionalFields: metadataFields,
           override(entry) {
@@ -151,7 +146,6 @@ export default class Config {
           }
           return [publicData, privateData];
         },
-        unyankAnswers: questionSetMerge,
         semantics: {
           override(entry) {
             if (entry.name === 'questions') {
@@ -174,8 +168,10 @@ export default class Config {
         },
       },
       'H5P.TrueFalse': {
-        yankAnswers: trueFalseYanker,
-        unyankAnswers: shallowMerge,
+        yankAnswers: yankByKeysFactory(
+          'correct',
+          ...metadataFields.map((f) => f.field.name),
+        ),
         semantics: {
           additionalFields: metadataFields,
         },

--- a/server/src/utils.spec.ts
+++ b/server/src/utils.spec.ts
@@ -135,7 +135,7 @@ describe('Utility functions', () => {
       result = recursiveMerge([{ a: { b: 1 } }], [{ a: { c: 2 } }]);
       expect(result).toStrictEqual([{ a: { b: 1, c: 2 } }]);
     });
-    it('returns rhs when types do not match, or lhs if rhs is null/undefined', () => {
+    it('returns rhs when types do not match and one value is null/undefined', () => {
       let result = recursiveMerge([1], null);
       expect(result).toStrictEqual([1]);
       expect(() => recursiveMerge([1], 'test')).toThrow(/Cannot merge/);

--- a/server/src/utils.spec.ts
+++ b/server/src/utils.spec.ts
@@ -116,9 +116,8 @@ describe('Utility functions', () => {
     it('merges objects', () => {
       let result = recursiveMerge({ a: 1 }, { b: 2 });
       expect(result).toStrictEqual({ a: 1, b: 2 });
-      // Keeps rhs when the keys exists in both
-      result = recursiveMerge({ a: 1 }, { a: 2 });
-      expect(result).toStrictEqual({ a: 2 });
+      // throws when the keys exists in both
+      expect(() => recursiveMerge({ a: 1 }, { a: 2 })).toThrow(/Cannot merge/);
       // Favors non-null
       result = recursiveMerge({ a: 1 }, { a: null });
       expect(result).toStrictEqual({ a: 1 });
@@ -127,11 +126,10 @@ describe('Utility functions', () => {
       expect(result).toStrictEqual({ a: { b: { c: 1, d: 2 } } });
     });
     it('merges arrays by index by default', () => {
-      // Keeps rhs when the values exists in both places
-      let result = recursiveMerge([1], [2]);
-      expect(result).toStrictEqual([2]);
+      // throws when the values exists in both places
+      expect(() => recursiveMerge([1], [2])).toThrow(/Cannot merge/);
       // Favors non-null
-      result = recursiveMerge([1, null, 3], [null, 2, null]);
+      let result = recursiveMerge([1, null, 3], [null, 2, null]);
       expect(result).toStrictEqual([1, 2, 3]);
       // Deeply merges arrays
       result = recursiveMerge([{ a: { b: 1 } }], [{ a: { c: 2 } }]);
@@ -140,8 +138,7 @@ describe('Utility functions', () => {
     it('returns rhs when types do not match, or lhs if rhs is null/undefined', () => {
       let result = recursiveMerge([1], null);
       expect(result).toStrictEqual([1]);
-      result = recursiveMerge([1], 'test');
-      expect(result).toStrictEqual('test');
+      expect(() => recursiveMerge([1], 'test')).toThrow(/Cannot merge/);
       result = recursiveMerge([1], undefined);
       expect(result).toStrictEqual([1]);
     });

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -165,6 +165,9 @@ export function mergeByIndex(
 }
 
 export function defaultValueMerge(lhs: unknown, rhs: unknown) {
+  if (lhs != null && rhs != null) {
+    throw new Error(`Cannot merge values: ${lhs} and ${rhs}`);
+  }
   return rhs ?? lhs;
 }
 


### PR DESCRIPTION
fixes openstax/ce#2174
depends on openstax/ce#2191

~This is a draft PR because I would like to merge this change after the one for 2191 but I wanted to go ahead and get this change ready. I thought that the two sets of changes together might be too much to review at once.~


- Make collaborator solutions private when the solutions are private
    - I moved some stuff around to try to keep implementation-specific ideas (config.ts) separated from the building blocks (AnswerYankers)
- Ensure CAT handles merging of public and private content in the same way as Enki and the exercise migration
    - It turns out that CAT was handling question sets very differently before this change
    - Also simplified the process of loading private content

I also wanted to work on moving some stuff out of `config.ts`, but ultimately that did not seem super important at the moment.
