### PR TITLE
Add isFreeResponseSupported field to multichoice

### DIFF
--- a/server/src/models/OpenStax/__snapshots__/H5PEditor.spec.ts.snap
+++ b/server/src/models/OpenStax/__snapshots__/H5PEditor.spec.ts.snap
@@ -105,6 +105,13 @@ exports[`H5PEditor alterLibrarySemantics does not mutate semantics and alters th
   {
     "default": false,
     "importance": "medium",
+    "label": "Supports Free Response",
+    "name": "isFreeResponseSupported",
+    "type": "boolean",
+  },
+  {
+    "default": false,
+    "importance": "medium",
     "label": "Solution Is Public",
     "name": "isSolutionPublic",
     "type": "boolean",

--- a/server/src/models/OpenStax/config.ts
+++ b/server/src/models/OpenStax/config.ts
@@ -93,6 +93,17 @@ const collaboratorSolutions: AdditionalField[] = [
   detailedSolution,
 ];
 
+const freeResponseCheckbox: AdditionalField = {
+  field: {
+    name: 'isFreeResponseSupported',
+    type: 'boolean',
+    importance: 'medium',
+    default: false as unknown as string,
+    label: 'Supports Free Response',
+  },
+  private: false,
+};
+
 export function newSupportedLibrary(
   options?: LibraryOptions,
 ): SupportedLibrary {
@@ -195,7 +206,11 @@ export default class Config {
       'H5P.MultiChoice': newSupportedLibrary({
         yankAnswers: yankByKeysFactory('answers'),
         semantics: {
-          additionalFields: [...collaboratorSolutions, publicSolution],
+          additionalFields: [
+            ...collaboratorSolutions,
+            freeResponseCheckbox,
+            publicSolution,
+          ],
           override(entry) {
             if (entry.name === 'behaviour') {
               const fields = entry.fields ?? (entry.fields = []);


### PR DESCRIPTION
part of openstax/ce#2185

Add free response checkbox to multiple choice questions

"It is for multi-choice questions only[...]"

Here's what it will look like when public solutions checkbox is also present:
<img width="659" alt="Screenshot 2024-03-28 at 3 34 30 PM" src="https://github.com/openstax/vscode-h5p/assets/33585550/d62e119a-c1a9-4de1-b46c-620f449b5a38">
