### PR TITLE
Bug fixes

### DIFF
--- a/server/src/models/OpenStax/FileContentStorage.spec.ts
+++ b/server/src/models/OpenStax/FileContentStorage.spec.ts
@@ -1,5 +1,5 @@
 import * as fsExtra from 'fs-extra';
-import OSStorage from './FileContentStorage';
+import OSStorage, { fixNamespaces } from './FileContentStorage';
 import mockfs from 'mock-fs';
 import path from 'path';
 import Config from './config';
@@ -568,5 +568,34 @@ describe('File Content Storage', () => {
         {} as unknown as IUser,
       ),
     ).toBe('1');
+  });
+
+  describe('fixNamespaces', () => {
+    it('adds mathml namespace', () => {
+      const content = {
+        x: [
+          '<math t="1"><mi a="test">x</mi></math>',
+          '<div>something</div>',
+          '<math><mrow xmlns:t="http://example.com" t:b="x"><mi>y</mi></mrow>' +
+            '</math>',
+          '<math><mi>z</mi></math>',
+          '<math xmlns="not-xhtml-namespace"><mi>w</mi></math>',
+        ].join('\n'),
+      };
+      fixNamespaces(content);
+      expect(content.x).toBe(
+        [
+          '<math t="1" xmlns="http://www.w3.org/1998/Math/MathML">' +
+            '<mi a="test">x</mi></math>',
+          '<div>something</div>',
+          '<math xmlns="http://www.w3.org/1998/Math/MathML">' +
+            '<mrow xmlns:t="http://example.com" t:b="x">' +
+            '<mi>y</mi>' +
+            '</mrow></math>',
+          '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>z</mi></math>',
+          '<math xmlns="not-xhtml-namespace"><mi>w</mi></math>',
+        ].join('\n'),
+      );
+    });
   });
 });

--- a/server/src/models/OpenStax/FileContentStorage.ts
+++ b/server/src/models/OpenStax/FileContentStorage.ts
@@ -39,7 +39,8 @@ function toTempName(pathname: string) {
 function getImageAttachments(images: Element[]) {
   return images
     .map((img) => img.getAttribute('src')?.trim())
-    .filter((src): src is string => src != null && src !== '');
+    .filter((src): src is string => src != null && src !== '')
+    .filter((src) => !src.startsWith('http'));
 }
 
 function updateAttachments(content: unknown, pathPrefix: string) {

--- a/server/src/models/OpenStax/__snapshots__/config.spec.ts.snap
+++ b/server/src/models/OpenStax/__snapshots__/config.spec.ts.snap
@@ -42,6 +42,24 @@ exports[`questionSetYanker yanks private data by subtype 1`] = `
       },
     },
     {
+      "library": "H5P.MultiChoice 1.16",
+      "params": {
+        "answers": [
+          {
+            "text": "<div>3</div>
+",
+          },
+          {
+            "text": "<div>4</div>
+",
+          },
+        ],
+        "isSolutionPublic": false,
+        "question": "<p>Given point a and point b, what is 2+2?</p>
+",
+      },
+    },
+    {
       "library": "H5P.Blanks 1.14",
       "params": {
         "isSolutionPublic": false,
@@ -64,6 +82,29 @@ exports[`questionSetYanker yanks private data by subtype 2`] = `
     },
     {
       "params": null,
+    },
+    {
+      "params": {
+        "answers": [
+          {
+            "correct": false,
+            "tipsAndFeedback": {
+              "chosenFeedback": "",
+              "notChosenFeedback": "",
+              "tip": "",
+            },
+          },
+          {
+            "correct": true,
+            "tipsAndFeedback": {
+              "chosenFeedback": "",
+              "notChosenFeedback": "",
+              "tip": "",
+            },
+          },
+        ],
+        "detailedSolution": "Something",
+      },
     },
     {
       "params": {

--- a/server/src/models/OpenStax/config.spec.ts
+++ b/server/src/models/OpenStax/config.spec.ts
@@ -43,6 +43,34 @@ describe('questionSetYanker', () => {
         },
         {
           params: {
+            question: '<p>Given point a and point b, what is 2+2?</p>\n',
+            answers: [
+              {
+                correct: false,
+                tipsAndFeedback: {
+                  tip: '',
+                  chosenFeedback: '',
+                  notChosenFeedback: '',
+                },
+                text: '<div>3</div>\n',
+              },
+              {
+                correct: true,
+                tipsAndFeedback: {
+                  tip: '',
+                  chosenFeedback: '',
+                  notChosenFeedback: '',
+                },
+                text: '<div>4</div>\n',
+              },
+            ],
+            detailedSolution: 'Something',
+            isSolutionPublic: false,
+          },
+          library: 'H5P.MultiChoice 1.16',
+        },
+        {
+          params: {
             media: {
               disableImageZooming: false,
             },

--- a/server/src/models/OpenStax/config.ts
+++ b/server/src/models/OpenStax/config.ts
@@ -1,8 +1,8 @@
 import * as H5P from '@lumieducation/h5p-server';
-import { Yanker, chain, yankByKeysFactory } from './AnswerYankers';
+import { Yanker, chain, yankByKeys, yankByKeysFactory } from './AnswerYankers';
 import { ISemanticsEntry } from '@lumieducation/h5p-server/build/src/types';
 import { assertTrue, assertValue } from '../../../../common/src/utils';
-import { QuestionSetQuestion, toQuestionSet } from './helpers';
+import { QuestionSetQuestion, toMultiChoice, toQuestionSet } from './helpers';
 
 type GetSolutionIsPublic = (content: Partial<unknown>) => boolean;
 
@@ -193,7 +193,21 @@ export default class Config {
         },
       }),
       'H5P.MultiChoice': newSupportedLibrary({
-        yankAnswers: yankByKeysFactory('answers'),
+        yankAnswers: (content) => {
+          const publicData = toMultiChoice(JSON.parse(JSON.stringify(content)));
+          const privateData = {};
+          const publicAnswers: Partial<unknown>[] = [];
+          const privateAnswers: Partial<unknown>[] = [];
+          publicData.answers
+            .map((a) => yankByKeys(a, ['correct', 'tipsAndFeedback']))
+            .forEach(([pub, priv]) => {
+              publicAnswers.push(pub);
+              privateAnswers.push(priv);
+            });
+          Reflect.set(privateData, 'answers', privateAnswers);
+          Reflect.set(publicData, 'answers', publicAnswers);
+          return [publicData, privateData];
+        },
         semantics: {
           additionalFields: [...collaboratorSolutions, publicSolution],
           override(entry) {

--- a/server/src/models/OpenStax/helpers.ts
+++ b/server/src/models/OpenStax/helpers.ts
@@ -10,6 +10,17 @@ export interface QuestionSet {
   questions: QuestionSetQuestion[];
 }
 
+export interface MultiChoiceAnswer {
+  correct: boolean;
+  text: string;
+  tipsAndFeedback: Partial<unknown>;
+}
+
+export interface MultiChoice {
+  question: string;
+  answers: MultiChoiceAnswer[];
+}
+
 export function isQuestionSet(
   content: Partial<unknown>,
 ): content is QuestionSet {
@@ -27,5 +38,25 @@ export function toQuestionSet(content: Partial<unknown>): QuestionSet {
   return assertValue(
     isQuestionSet(content) ? content : undefined,
     'BUG: tried to interpret a non-QuestionSet as a QuestionSet',
+  );
+}
+
+export function isMultiChoice(
+  content: Partial<unknown>,
+): content is MultiChoice {
+  return (
+    'question' in content &&
+    'answers' in content &&
+    Array.isArray(content['answers']) &&
+    content['answers'].every(
+      (a) => 'correct' in a && 'text' in a && 'tipsAndFeedback' in a,
+    )
+  );
+}
+
+export function toMultiChoice(content: Partial<unknown>): MultiChoice {
+  return assertValue(
+    isMultiChoice(content) ? content : undefined,
+    'BUG: tried to interpret a non-MultiChoice as a MultiChoice',
   );
 }


### PR DESCRIPTION
part of openstax/ce#2205

Fixes:
- Web urls not supported for images because they were interpreted as attachments (i.e. expected to be on disk)
- CKEditor sometimes removes MathML xml namespace declaration (related to openstax/ce#2202)
- Keep `text` (answer choice) in public content.json for H5P.MultiChoice
