### PR TITLE
Fix the MathType editor's position on the screen

### DIFF
--- a/client/src/app/viewers/H5PViewerComponent.tsx
+++ b/client/src/app/viewers/H5PViewerComponent.tsx
@@ -20,6 +20,38 @@ export default class H5PViewerComponent extends React.Component<{
   private contentService: ContentService;
   private h5pUrl: string;
 
+  private createViewportUpdateEvent(elem: Element, viewport: VisualViewport) {
+    return new CustomEvent('viewportUpdate', {
+      detail: {
+        parentViewport: viewport,
+        boundingClientRect: elem.getBoundingClientRect(),
+      },
+    });
+  }
+
+  private notifyIframes() {
+    const viewport = window.visualViewport;
+    if (viewport != null) {
+      // Forward viewport events (scroll/resize) to all iframes
+      // These iframes contain the h5p editor instances
+      Array.from(document.querySelectorAll('iframe')).forEach((frame) => {
+        frame.contentDocument?.dispatchEvent(
+          this.createViewportUpdateEvent(frame, viewport),
+        );
+      });
+    }
+  }
+
+  private installViewportUpdateEvent() {
+    const notifyIframes = this.notifyIframes.bind(this);
+    addEventListener('scroll', notifyIframes);
+    addEventListener('resize', notifyIframes);
+  }
+
+  public override componentDidMount() {
+    this.installViewportUpdateEvent();
+  }
+
   override render() {
     return (
       <div className="App">

--- a/server/scripts/mathtype-plugin-js.patch
+++ b/server/scripts/mathtype-plugin-js.patch
@@ -24,15 +24,15 @@
 >   const height = featureDef.height?.concat("px") || "400px";
 > 
 >   [htmlWin, html, body].forEach((el) => {
->     el.style.minWidth = width;
->     el.style.minHeight = height;
+>     el.style.width = width;
+>     el.style.height = height;
 >   });
 >   
 >   htmlWin.id = name;
->   htmlWin.style.padding = "10px";
+>   htmlWin.style.padding = "10px 25px 30px 10px";
 >   htmlWin.style.backgroundColor = "white";
 >   htmlWin.style.border = "1px solid gray";
->   htmlWin.style.position = "absolute";
+>   htmlWin.style.position = "fixed";
 >   
 >   titleBar.style.display = "flex";
 >   titleEl.style.boxSizing = "border-box";

--- a/server/static/editor-plugins/addons.js
+++ b/server/static/editor-plugins/addons.js
@@ -43,7 +43,8 @@ function getFixMathTypeDialog() {
   }
 
   const isMathTypeNode = (node) =>
-    node.id === 'wrs_code' || node.id?.startsWith('wrs_modal_dialogContainer')
+    node.id === 'wrs_code' ||
+    node.classList?.contains('wrs_modal_dialogContainer') === true
   const observe = new MutationObserver(function (mutations) {
     const addedOrRemovedDialog = mutations.some(
       (mutation) =>

--- a/server/static/editor-plugins/addons.js
+++ b/server/static/editor-plugins/addons.js
@@ -1,10 +1,99 @@
 // https://h5p.org/adding-text-editor-buttons
 
+function getFixMathTypeDialog() {
+  let offsetTop = 0;
+  let viewportHeight = 0;
+  let parentOffsetTop = 0;
+  let parentWidth = 0;
+  let parentHeight = 0;
+  let mathTypeInstances = [];
+  let waitingForUpdate = false;
+
+  const setMathTypePosition = () => {
+    const visibleInstances = mathTypeInstances.filter(
+      (editor) => !editor.classList.contains('wrs_closed')
+    );
+    if (waitingForUpdate || visibleInstances.length === 0) return;
+    waitingForUpdate = true;
+    requestAnimationFrame(() => {
+      try {
+        const boundingRects = visibleInstances
+          .map((dialog) => dialog.getBoundingClientRect())
+        const instanceHeights = boundingRects.map((rect) => rect.height)
+        const totalHeight = instanceHeights
+          .reduce((ax, x) => ax + x);
+        const startingOffsetTop =
+          offsetTop - parentOffsetTop + viewportHeight / 2 - totalHeight / 2;
+        let relOffsetTop = 0;
+        visibleInstances.forEach((dialog, idx) => {
+          const dialogWidth = boundingRects[idx].width;
+          const top = Math.min(
+            Math.max(startingOffsetTop, 0), parentHeight - totalHeight
+          ) + relOffsetTop;
+          const left = Math.max((parentWidth / 2 - dialogWidth / 2), 0);
+          relOffsetTop += instanceHeights[idx];
+          dialog.style.inset = `${top}px ${left}px 0px`;
+        });
+      } catch (e) {
+        console.error(e);
+      } finally {
+        waitingForUpdate = false;
+      }
+    });
+  }
+
+  const isMathTypeNode = (node) =>
+    node.id === 'wrs_code' || node.id?.startsWith('wrs_modal_dialogContainer')
+  const observe = new MutationObserver(function (mutations) {
+    const addedOrRemovedDialog = mutations.some(
+      (mutation) =>
+        Array.from(mutation.addedNodes).some(isMathTypeNode) ||
+        Array.from(mutation.removedNodes).some(isMathTypeNode)
+    );
+    const shouldUpdate = addedOrRemovedDialog || (
+      mathTypeInstances.length > 0 &&
+      // Look for cases where a dialog was resized or hidden
+      mutations
+        .some((mutation) =>
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'class' &&
+          mathTypeInstances.some((instance) => mutation.target === instance)
+        )
+    );
+    if (addedOrRemovedDialog) {
+      mathTypeInstances = Array.from(
+        document.querySelectorAll('#wrs_code, .wrs_modal_dialogContainer')
+      );
+    }
+    // Move the dialogs when they are added, hidden/removed, or resized
+    if (shouldUpdate) {
+      setMathTypePosition();
+    }
+  });
+
+  observe.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+  });
+
+  return function(e) {
+    offsetTop = e.detail.parentViewport.pageTop;
+    viewportHeight = e.detail.parentViewport.height;
+    parentOffsetTop =
+      e.detail.boundingClientRect.top + e.detail.parentViewport.pageTop;
+    parentWidth = e.detail.boundingClientRect.width;
+    parentHeight = e.detail.boundingClientRect.height;
+    setMathTypePosition();
+  }
+}
+
 (function ($) {
   $(document).ready(function () {
     if (!window.CKEDITOR) {
       return;
     }
+    document.addEventListener('viewportUpdate', getFixMathTypeDialog())
 
     // Register our plugin
     H5PEditor.HtmlAddons = H5PEditor.HtmlAddons || {};


### PR DESCRIPTION
part of openstax/ce#2205

If multiple instances are opened, they are stacked vertically.

This also moves the math source editor (wrs_code) in the same manner.

Multiple h5p editor instances can be opened at once. Each h5p editor instance has its own iframe.

The custom viewportUpdate event is sent to each iframe.

Consequently, when multiple h5p editors are opened and each has one or more MathType editor instances open, all MathType editors should be updated within their respective iframes.

Additionally, the MathType editor instances should remain contained within their respective iframes (see `top` in addons.js).

## Demo

https://github.com/openstax/vscode-h5p/assets/33585550/1f4eda15-ceb4-47ca-8c24-d1ceeadb1633

