### PR TITLE
2211 context update

### DIFF
--- a/client/src/app/components/OpenStax/Context.tsx
+++ b/client/src/app/components/OpenStax/Context.tsx
@@ -1,33 +1,17 @@
-import BasicFormComponent from './BasicFormComponent';
-import SingleInput from './SingleInput';
-import { SingleInputProps } from './types';
+import { InputSet, InputSetProps } from './InputSet';
 import { patternValidationFactory } from './utils';
 
-const moduleIdPattern = /^m\d+#[A-Z][A-Z0-9-_]*$/i;
+const moduleIdPattern = /^m\d+(#[A-Za-z][A-Za-z0-9-_]*)?$/;
 const placeholder = 'm00000#element-id';
 
-export default function Context(props: SingleInputProps) {
+export default function Context(props: InputSetProps) {
   const validator = patternValidationFactory(moduleIdPattern, props);
   const subProps = {
     ...props,
-    handleInputChange: (value: string) => {
-      props.handleInputChange(value, validator(value));
+    handleInputChange: (index: number, value: string) => {
+      props.handleInputChange(index, value, validator(value));
     },
   };
 
-  return (
-    <BasicFormComponent
-      {...subProps}
-      title={'Context'}
-      content={
-        <div className="col-12">
-          <SingleInput
-            {...subProps}
-            style={{ width: '100%' }}
-            placeholder={placeholder}
-          />
-        </div>
-      }
-    />
-  );
+  return <InputSet {...subProps} title={'Context'} placeholder={placeholder} />;
 }

--- a/client/src/app/components/OpenStax/OpenstaxMetadataForm.tsx
+++ b/client/src/app/components/OpenStax/OpenstaxMetadataForm.tsx
@@ -41,11 +41,11 @@ type SingleInputs = {
   dok: InputState;
   time: InputState;
   errata_id: InputState;
-  context: InputState;
 };
 
 type InputSets = {
   books: InputState[];
+  context: InputState[];
 };
 
 export type BookInputs = {
@@ -208,10 +208,10 @@ const exerciseInputs: Array<
   },
   {
     key: 'context',
-    make(inputHandlerFactory) {
+    make(_, inputSetHandlerFactory) {
       return (
         <Context
-          {...inputHandlerFactory(this.key)}
+          {...inputSetHandlerFactory(this.key)}
           required={this.isRequired}
         />
       );
@@ -297,11 +297,11 @@ export default class OpenstaxMetadataForm extends React.Component<FormProps> {
   public override state: FormState = {
     errata_id: { ...defaultInputState },
     nickname: { ...defaultInputState },
-    context: { ...defaultInputState },
     blooms: { ...defaultInputState },
     assignment_type: { ...defaultInputState },
     dok: { ...defaultInputState },
     time: { ...defaultInputState },
+    context: [],
     books: [],
     aplo: [],
     lo: [],

--- a/client/src/app/components/OpenStax/metadata-adaptor.ts
+++ b/client/src/app/components/OpenStax/metadata-adaptor.ts
@@ -38,8 +38,6 @@ function getBookMetadata(formData: FormState): BookMetadata[] {
 }
 
 export function adaptToNetworkModel(formData: FormState): NetworkMetadata {
-  const noContext = formData['context'].value === '';
-  const splitContext = formData['context'].value.split('#');
   return {
     nickname: formData.nickname.value,
     errata_id: formData.errata_id.value,
@@ -53,8 +51,9 @@ export function adaptToNetworkModel(formData: FormState): NetworkMetadata {
         ? null
         : formData.assignment_type.value,
     time: formData.time.value === '' ? null : formData.time.value,
-    feature_page: noContext ? null : assertValue(splitContext[0]),
-    feature_id: noContext ? null : assertValue(splitContext[1]),
+    context: formData.context
+      .map((state) => state.value)
+      .filter((v) => v !== ''),
   };
 }
 
@@ -104,11 +103,6 @@ export function adaptToFormModel(
   const formState: Partial<FormState> = canonicalBooksToFormState(
     canonicalMetadata.books,
   );
-  if (!isFalsy(canonicalMetadata.feature_page)) {
-    formState.context = toInputState(
-      `${canonicalMetadata.feature_page}#${canonicalMetadata.feature_id}`,
-    );
-  }
   if (!isFalsy(canonicalMetadata.blooms)) {
     formState.blooms = toInputState(canonicalMetadata.blooms);
   }
@@ -122,5 +116,6 @@ export function adaptToFormModel(
     formState.time = toInputState(canonicalMetadata.time);
   }
   formState.errata_id = toInputState(canonicalMetadata.errata_id);
+  formState.context = (canonicalMetadata.context ?? []).map(toInputState);
   return formState;
 }

--- a/client/src/app/components/OpenStax/specs/Inputs.spec.tsx
+++ b/client/src/app/components/OpenStax/specs/Inputs.spec.tsx
@@ -16,7 +16,7 @@ import ConfirmationDialog from '../ConfirmationDialog';
 
 function testSingleInputValidation(
   factory: (state: SingleInputProps) => React.ReactElement<SingleInputProps>,
-  valuesToTest: [string, boolean][],
+  valuesToTest: [value: string, isValid: boolean][],
 ) {
   let value = '';
   let isValid = true;
@@ -41,7 +41,7 @@ function testSingleInputValidation(
 
 function testInputSetValidation(
   factory: (state: InputSetProps) => React.ReactElement<InputSetProps>,
-  valuesToTest: [string, boolean][][],
+  valuesToTest: [value: string, isValid: boolean][][],
 ) {
   const inputStates = range(valuesToTest[0].length).map(() => ({
     value: '',
@@ -323,15 +323,19 @@ describe('Inputs', () => {
 
   describe('context', () => {
     it('validates values', () => {
-      testSingleInputValidation(
+      testInputSetValidation(
         (state) => <Context {...state} />,
         [
-          ['m00123', false],
-          ['invalid', false],
-          ['m00123#fs-12345', true],
-          ['m00123#', false],
-          ['m00123#a', true],
-          ['m00123#12-asd', false],
+          [
+            ['m00123', true],
+            ['invalid', false],
+            ['m00123#fs-12345', true],
+          ],
+          [
+            ['m00123#', false],
+            ['m00123#a', true],
+            ['m00123#12-asd', false],
+          ],
         ],
       );
     });

--- a/client/src/app/components/OpenStax/specs/OpenstaxMetadataForm.spec.tsx
+++ b/client/src/app/components/OpenStax/specs/OpenstaxMetadataForm.spec.tsx
@@ -155,8 +155,7 @@ describe('OpenstaxMetadataForm', () => {
     //   it(`can ${isAdd ? 'add' : 'remove'} inputs in a set`, async () => {
     //     const { container } = await initFormWithMinData({
     //       formDataOverride: {
-    //         feature_page: 'a/b/c',
-    //         feature_id: 'fs-123',
+    //         context: ['a/b/c#fs-123']
     //       },
     //     });
     //     const inputCountBefore = container.querySelectorAll('input').length;
@@ -350,8 +349,7 @@ describe('OpenstaxMetadataForm', () => {
   });
   describe('encode/decode form state', () => {
     const formDataEncoded = {
-      feature_page: 'm00003',
-      feature_id: 'term-03',
+      context: ['m00003#term-03'],
       books: [
         { name: 'stax-psy', lo: ['00-00-01'] },
         {
@@ -383,8 +381,7 @@ describe('OpenstaxMetadataForm', () => {
       const errorValue = contextInitialValue + '+';
       const { openstaxForm, getByDisplayValue } = await initFormWithMinData({
         formDataOverride: {
-          feature_page: moduleNumber,
-          feature_id: elementId,
+          context: [`${moduleNumber}#${elementId}`],
         },
       });
       const moduleIdInput = await getByDisplayValue(contextInitialValue);

--- a/client/src/app/components/OpenStax/specs/__snapshots__/OpenstaxMetadataForm.spec.tsx.snap
+++ b/client/src/app/components/OpenStax/specs/__snapshots__/OpenstaxMetadataForm.spec.tsx.snap
@@ -18,10 +18,9 @@ exports[`OpenstaxMetadataForm Book inputs correctly modifies inputs 1`] = `
       "name": "stax-pophealth",
     },
   ],
+  "context": [],
   "dok": null,
   "errata_id": "test",
-  "feature_id": null,
-  "feature_page": null,
   "nickname": "new",
   "time": null,
 }
@@ -50,10 +49,9 @@ exports[`OpenstaxMetadataForm Book inputs correctly modifies inputs in a set 1`]
       "name": "stax-amfg",
     },
   ],
+  "context": [],
   "dok": null,
   "errata_id": "test",
-  "feature_id": null,
-  "feature_page": null,
   "nickname": "new",
   "time": null,
 }
@@ -77,10 +75,9 @@ exports[`OpenstaxMetadataForm Book inputs handleBookChange keeps input values wh
       "name": "stax-psy",
     },
   ],
+  "context": [],
   "dok": null,
   "errata_id": "test",
-  "feature_id": null,
-  "feature_page": null,
   "nickname": "new",
   "time": null,
 }
@@ -101,6 +98,7 @@ exports[`OpenstaxMetadataForm encode/decode form state decodes form state when l
   "aacn": [],
   "aplo": [],
   "books": [],
+  "context": [],
   "errata_id": {
     "isValid": true,
     "value": "test",
@@ -132,10 +130,11 @@ exports[`OpenstaxMetadataForm encode/decode form state decodes form state when l
       "science_practice": "concept-explanation",
     },
   ],
+  "context": [
+    "m00003#term-03",
+  ],
   "dok": null,
   "errata_id": "test",
-  "feature_id": "term-03",
-  "feature_page": "m00003",
   "nickname": "new",
   "time": null,
 }

--- a/client/src/app/components/OpenStax/specs/__snapshots__/metadata-adaptor.spec.ts.snap
+++ b/client/src/app/components/OpenStax/specs/__snapshots__/metadata-adaptor.spec.ts.snap
@@ -9,10 +9,9 @@ exports[`Metadata Adaptor Adapts form data to network model 1`] = `
       "name": "stax-should-now-be-saved",
     },
   ],
+  "context": [],
   "dok": null,
   "errata_id": "fffffff",
-  "feature_id": null,
-  "feature_page": null,
   "nickname": "test",
   "time": null,
 }
@@ -35,6 +34,7 @@ exports[`Metadata Adaptor Saves and loads values for books 1`] = `
       "name": "stax-apsomething",
     },
   ],
+  "context": [],
   "errata_id": "fffffff",
 }
 `;
@@ -45,10 +45,11 @@ exports[`Metadata Adaptor saves and loads optional values 1`] = `
   "attachments": [],
   "blooms": "1",
   "books": [],
+  "context": [
+    "m12345#fs-12345",
+  ],
   "dok": "1",
   "errata_id": "fffffff",
-  "feature_id": "fs-12345",
-  "feature_page": "m12345",
   "time": "Short",
 }
 `;

--- a/client/src/app/components/OpenStax/specs/metadata-adaptor.spec.ts
+++ b/client/src/app/components/OpenStax/specs/metadata-adaptor.spec.ts
@@ -10,7 +10,7 @@ const defaultInputState: InputState = { value: '', isValid: true };
 const BASE_FORM_STATE: FormState = {
   errata_id: { ...defaultInputState, value: 'fffffff' },
   nickname: { ...defaultInputState, value: 'test' },
-  context: { ...defaultInputState },
+  context: [],
   blooms: { ...defaultInputState },
   assignment_type: { ...defaultInputState },
   dok: { ...defaultInputState },
@@ -97,7 +97,7 @@ describe('Metadata Adaptor', () => {
     // GIVEN: Optional input values
     const state: FormState = {
       ...BASE_FORM_STATE,
-      context: { ...defaultInputState, value: 'm12345#fs-12345' },
+      context: [{ ...defaultInputState, value: 'm12345#fs-12345' }],
       blooms: { ...defaultInputState, value: '1' },
       assignment_type: { ...defaultInputState, value: 'something' },
       dok: { ...defaultInputState, value: '1' },

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -5,8 +5,7 @@ export interface NetworkMetadata {
   assignment_type: string | null;
   dok: string | null;
   time: string | null;
-  feature_page: string | null;
-  feature_id: string | null;
+  context: string[];
   books: BookMetadata[];
 }
 
@@ -27,8 +26,7 @@ export interface CanonicalMetadata {
   assignment_type?: string;
   dok?: string;
   time?: string;
-  feature_page?: string;
-  feature_id?: string;
+  context: string[];
   books: BookMetadata[];
   attachments: string[];
 }


### PR DESCRIPTION
fixes openstax/ce#2211

- Update pattern for context validation (extra change: made this case sensitive because it really should have been already)
- Element id is not required in context
- Supports multiple context entries
- Entries stored as list of strings in link notation (i.e. m00000#fs-21484)

Please let me know if you know of a more specific pattern for module names/ids.

<img width="967" alt="Screenshot 2024-04-23 at 3 41 17 PM" src="https://github.com/openstax/vscode-h5p/assets/33585550/4ee8e28d-e05d-4459-90f7-8590ebd97606">

